### PR TITLE
Fix correspondences error for Z6xx(B) stages

### DIFF
--- a/stage/motor_ctrl/stage_info.py
+++ b/stage/motor_ctrl/stage_info.py
@@ -22,11 +22,11 @@ def stage_name_from_get_hw_info(m):
             _print_stage_detection_improve_message(m)
             return None  #Open circuit - no motor connected.
         elif stage_type == 0x02:
-            return 'Z706'
+            return 'Z606(B)'
         elif stage_type == 0x03:
-            return 'Z712'
+            return 'Z612(B)'
         elif stage_type == 0x04:
-            return 'Z725'
+            return 'Z625(B)'
         elif stage_type == 0x05:
             return 'CR1-Z7'
         elif stage_type == 0x06:


### PR DESCRIPTION
Hi kzhao1228, 

Many thanks for developing this library!

I just encountered a correspondence issue for a Z625(B) stage, and it seems that the Z7xx motors in stage/motor_ctrl/stage_info.py do actually correspond to the Z6xx(B) stages in stage/motor_ctrl/MG17APTServer.ini.

This just corrects it.